### PR TITLE
Some simple unit tests using pytest

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --ignore scripts --cov-report term-missing --cov medleydb

--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,12 @@ setup(
     ],
     keywords='dataset multitrack music',
     license='MIT',
-    install_requires=['pyyaml']
+    install_requires=['pyyaml'],
+    extras_require={
+        'tests': [
+            'pytest',
+            'pytest-cov',
+            'pytest-pep8',
+        ],
+    },
 )

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -1,0 +1,8 @@
+import medleydb as mdb
+
+def test_all():
+    assert len(mdb.load_all_multitracks()) > 0
+
+
+def test_melody():
+    assert len(mdb.load_melody_multitracks()) > 0

--- a/tests/test_sox.py
+++ b/tests/test_sox.py
@@ -1,0 +1,16 @@
+import medleydb as mdb
+from medleydb import sox
+
+def noop(*args, **kwargs):
+    pass
+
+
+def test_preview(monkeypatch):
+    monkeypatch.setattr(sox, "quick_play", noop)
+    track = mdb.load_all_multitracks()[0]
+    mdb.preview_audio(track)
+
+
+# TODO: Actually test sox. This test only tests the preview_audio()
+# function by mocking the sox module (replacing sox.quick_play()
+# with a function that does nothing)

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -1,0 +1,17 @@
+import pytest
+
+import medleydb as mdb
+
+@pytest.fixture(params=(
+    'violin',
+))
+def instrument(request):
+    return request.param
+
+
+def test_instrument(instrument):
+    assert mdb.is_valid_instrument(instrument)
+
+
+def test_instrument_files(instrument):
+    assert len(mdb.get_files_for_instrument(instrument)) > 0


### PR DESCRIPTION
This PR implements some simple unit tests that test several aspect of the package. You can run them using

    $ py.test

(make sure to install the package using `pip install -e .[tests]` first)