### PR TITLE
PEP8 style

### DIFF
--- a/medleydb/__init__.py
+++ b/medleydb/__init__.py
@@ -8,12 +8,12 @@ from os import environ
 
 logging.basicConfig(level=logging.CRITICAL)
 
-assert "MEDLEYDB_PATH" in environ, """The environment variable MEDLEYDB_PATH 
+assert "MEDLEYDB_PATH" in environ, """The environment variable MEDLEYDB_PATH
 is not set. Set the value of MEDLEYDB_PATH to your local path to MedeleyDB."""
 
 MEDLEYDB_PATH = environ["MEDLEYDB_PATH"]
 
-assert path.exists(MEDLEYDB_PATH), """The path: %s set for MEDLEYDB_PATH does 
+assert path.exists(MEDLEYDB_PATH), """The path: %s set for MEDLEYDB_PATH does
 not exist.""" % MEDLEYDB_PATH
 
 INST_TAXONOMY = path.join(path.dirname(__file__), 'taxonomy.yaml')
@@ -23,5 +23,19 @@ MELODY_DIR = path.join(ANNOTATION_DIR, 'Melody_Annotations')
 PITCH_DIR = path.join(ANNOTATION_DIR, 'Pitch_Annotations')
 RANKINGS_DIR = path.join(ANNOTATION_DIR, 'Stem_Rankings')
 
-from .utils import *
-from .multitrack import *
+from .utils import (
+    load_melody_multitracks,
+    load_all_multitracks,
+    load_multitracks,
+    get_files_for_instrument,
+    preview_audio
+)
+
+from .multitrack import (
+    MultiTrack,
+    Track,
+    get_duration,
+    read_annotation_file,
+    get_valid_instrument_labels,
+    is_valid_instrument
+)

--- a/medleydb/multitrack.py
+++ b/medleydb/multitrack.py
@@ -79,7 +79,10 @@ class MultiTrack(object):
         self._meta_basename = _METADATA_FMT % self.track_id
         self._meta_path = os.path.join(mtrack_path, self._meta_basename)
         self._stem_dir_basename = _STEMDIR_FMT % self.track_id
-        self._stem_dir_path = os.path.join(mtrack_path, self._stem_dir_basename)
+        self._stem_dir_path = os.path.join(
+            mtrack_path,
+            self._stem_dir_basename
+        )
         self._raw_dir_basename = _RAWDIR_FMT % self.track_id
         self._raw_dir_path = os.path.join(mtrack_path, self._raw_dir_basename)
         self._mix_basename = _MIX_FMT % self.track_id
@@ -116,14 +119,14 @@ class MultiTrack(object):
         self.dominant_stem = self._get_dominant_stem()
 
     def _load_metadata(self):
-        """Load the metadata file. 
+        """Load the metadata file.
         """
         with open(self._meta_path, 'r') as f_in:
             metadata = yaml.load(f_in)
         return metadata
 
     def _parse_metadata(self):
-        """Parse metadata dictionary. 
+        """Parse metadata dictionary.
         """
         stems = []
         raw_audio = []
@@ -155,7 +158,7 @@ class MultiTrack(object):
         return stems, raw_audio
 
     def _get_melody_annotations(self):
-        """Fill melody annotations if files exists. 
+        """Get melody annotations if files exists.
         """
         melody1_fname = _MELODY1_FMT % self.track_id
         melody2_fname = _MELODY2_FMT % self.track_id
@@ -172,7 +175,7 @@ class MultiTrack(object):
         )
 
     def _get_dominant_stem(self):
-        """Fill dominant stem if files exists.
+        """Get dominant stem if files exists.
         """
         rankings_fname = _RANKING_FMT % self.track_id
         rankings_fpath = os.path.join(RANKINGS_DIR, rankings_fname)
@@ -189,80 +192,88 @@ class MultiTrack(object):
                         instrument = stem_dict['S' + s]['instrument']
                         component = stem_dict['S' + s]['component']
                         file_name = stem_dict['S' + s]['filename']
-                        file_path = os.path.join(self._stem_dir_path, file_name)
+                        file_path = os.path.join(
+                            self._stem_dir_path, file_name
+                        )
 
-                        track = Track(instrument=instrument, file_path=file_path,
-                                      component=component, stem_idx='S' + s,
-                                      mix_path=self.mix_path)
+                        track = Track(
+                            instrument=instrument,
+                            file_path=file_path,
+                            component=component,
+                            stem_idx='S' + s,
+                            mix_path=self.mix_path
+                        )
 
                         return track
         return None
 
     def melody_tracks(self):
-        """Get list of tracks that contain melody. 
+        """Get list of tracks that contain melody.
 
         Returns:
-            List of track objects where component='melody'. 
+            List of track objects where component='melody'.
 
         """
         return [track for track in self.stems if track.component == 'melody']
 
     def bass_tracks(self):
-        """Get list of tracks that contain bass. 
+        """Get list of tracks that contain bass.
 
         Returns:
-            List of track objects where component='bass'. 
-          
+            List of track objects where component='bass'.
+
         """
         return [track for track in self.stems if track.component == 'bass']
 
     def num_stems(self):
-        """Number of stems. 
+        """Number of stems.
 
         Returns:
-            Number of stems (as an int). 
-          
+            Number of stems (as an int).
+
         """
         return len(self.stems)
 
     def num_raw(self):
-        """Number of raw audio files. 
+        """Number of raw audio files.
 
         Returns:
-            Number of raw audio files (as an int). 
-          
+            Number of raw audio files (as an int).
+
         """
         return len(self.raw_audio)
 
     def stem_filepaths(self):
-        """Get list of filepaths to stem files.  
+        """Get list of filepaths to stem files.
 
         Returns:
-            List of filepaths to stems. 
-          
+            List of filepaths to stems.
+
         """
         return [track.file_path for track in self.stems]
 
     def raw_filepaths(self):
-        """Get list of filepaths to raw audio files.  
+        """Get list of filepaths to raw audio files.
 
         Returns:
             List of filepaths to raw audio files.
-          
+
         """
         return [track.file_path for track in self.raw_audio]
 
     def raw_from_stem(self, stem_idx):
-        """Get all raw audio tracks that are children of a given stem.  
+        """Get all raw audio tracks that are children of a given stem.
 
         Args:
             stem_idx (int): stem index (eg. 2 for stem S02)
 
         Returns:
-            List of Track objects. 
-          
+            List of Track objects.
+
         """
-        return [track for track in self.raw_audio if track.stem_idx == stem_idx]
+        return [
+            track for track in self.raw_audio if track.stem_idx == stem_idx
+        ]
 
 
 class Track(object):
@@ -309,7 +320,7 @@ class Track(object):
             self.pitch_annotation = self._get_pitch_annotation()
 
     def _format_index(self, index):
-        """Load stem or raw index. Reformat if in string form. 
+        """Load stem or raw index. Reformat if in string form.
         """
         if isinstance(index, str):
             return int(index.strip('S').strip('R'))
@@ -319,7 +330,7 @@ class Track(object):
             return int(index)
 
     def _get_pitch_annotation(self):
-        """Fill pitch annotation if file exists. 
+        """Get pitch annotation if file exists.
         """
         fname = _PITCH_FMT % os.path.basename(self.file_path).split('.')[0]
         pitch_annotation_fpath = os.path.join(PITCH_DIR, fname)
@@ -328,7 +339,7 @@ class Track(object):
 
 
 def _path_basedir(path):
-    """Get the name of the lowest directory of a path. 
+    """Get the name of the lowest directory of a path.
     """
     norm_path = os.path.normpath(path)
     return os.path.basename(norm_path)
@@ -380,7 +391,7 @@ def get_duration(wave_fpath):
     nsamples = fpath.getnframes()
     sample_rate = fpath.getframerate()
     fpath.close()
-    return float(nsamples)/float(sample_rate)
+    return float(nsamples) / float(sample_rate)
 
 
 def read_annotation_file(fpath, num_cols=None):
@@ -403,7 +414,7 @@ def read_annotation_file(fpath, num_cols=None):
 
     Args:
         fpath (str): Path to annotation file.
-        num_cols (int, optionals): Number of columns to read. If specified, 
+        num_cols (int, optionals): Number of columns to read. If specified,
             will only read the return num_cols columns of the annotation file.
 
     Returns:

--- a/medleydb/sox.py
+++ b/medleydb/sox.py
@@ -47,7 +47,7 @@ def sox(args):
     """Pass an argument list to SoX.
 
     Args:
-        args (list): Argument list for SoX. The first item can, but does not 
+        args (list): Argument list for SoX. The first item can, but does not
             need to, be 'sox'.
 
     Returns:
@@ -66,9 +66,9 @@ def sox(args):
         status = process_handle.wait()
         logging.info(process_handle.stdout)
         return status == 0
-    except OSError, error_msg:
+    except OSError as error_msg:
         logging.error("OSError: SoX failed! %s", error_msg)
-    except TypeError, error_msg:
+    except TypeError as error_msg:
         logging.error("TypeError: %s", error_msg)
     return False
 
@@ -80,9 +80,9 @@ def rm_silence(input_file, output_file,
     Args:
         input_file (str): Path to input audio file.
         output_file (str): Path to output audio file.
-        sil_pct_thresh (float, optional): Silence threshold as percentage of 
+        sil_pct_thresh (float, optional): Silence threshold as percentage of
             maximum sample amplitude.
-        min_voicing_duration (float, optional): Minimum amout of time required 
+        min_voicing_duration (float, optional): Minimum amout of time required
             to be considered non-silent.
 
     Returns:
@@ -112,10 +112,10 @@ def fade(input_file, output_file, fade_in_time=1, fade_out_time=8,
         output_file (str): File for writing output.
         fade_in_time (float, optional): Number of seconds of fade in.
         fade_out_time (float, optional): Number of seconds of fade out.
-        fade_shape (str, optional): Shape of fade. 
-            'q' for quarter sine (default), 
-            'h'for half sine, 
-            't' for linear, 
+        fade_shape (str, optional): Shape of fade.
+            'q' for quarter sine (default),
+            'h'for half sine,
+            't' for linear,
             'l' for logarithmic
             'p' for inverted parabola.
 
@@ -141,12 +141,12 @@ def quick_play(input_file, duration=5, use_fade=False, remove_silence=False):
         >>> quick_play('tuba_stem.wav', remove_silence=True)
         # preview 10 seconds of audio with a fade in and out:
         >>> quick_play('fancy_audio.wav', duration=10, use_fade=True)
-        
+
     Args:
         input_file (str): Audio file to play.
         duration (float, optional): Length of excerpt in seconds.
         use_fade (bool, optional): If true, apply a fade in and fade out.
-        remove_silence (bool, optional): If true, forces entire segment to have 
+        remove_silence (bool, optional): If true, forces entire segment to have
             sound by removing silence.
 
     """
@@ -160,7 +160,7 @@ def quick_play(input_file, duration=5, use_fade=False, remove_silence=False):
     if not use_fade:
         play(tmp_file, end_t=duration)
     else:
-        tmp_file2 = tmp.mktemp(suffix=".%s" % ext.strip("."), 
+        tmp_file2 = tmp.mktemp(suffix=".%s" % ext.strip("."),
                                dir=tmp.gettempdir())
         fade(tmp_file, tmp_file2, fade_in_time=0.5, fade_out_time=1)
         play(tmp_file2, end_t=duration)
@@ -188,7 +188,7 @@ def play(input_file, start_t=0, end_t=None):
     """
     assert_sox()
 
-    args = ["play", "--norm", "--no-show-progress", input_file, 'trim', 
+    args = ["play", "--norm", "--no-show-progress", input_file, 'trim',
             "%f" % start_t]
     if end_t:
         args.append("=%f" % end_t)
@@ -199,4 +199,3 @@ def play(input_file, start_t=0, end_t=None):
     logging.info(process_handle.stdout)
 
     return status == 0
-    

--- a/medleydb/utils.py
+++ b/medleydb/utils.py
@@ -17,7 +17,7 @@ def load_melody_multitracks():
         >>> melody_multitracks = load_melody_multitracks()
 
     Returns:
-        melody_multitracks (list): List of multitrack objects. 
+        melody_multitracks (list): List of multitrack objects.
 
     """
     multitracks = load_all_multitracks()
@@ -75,12 +75,14 @@ def get_files_for_instrument(instrument, multitrack_list=None):
                           'path/to/ArtistName2_TrackName2', \
                           'path/to/ArtistName3_TrackName3']
         >>> multitrack_subset = load_multitracks(track_list)
-        >>> violin_files = get_files_for_instrument('violin', multitrack_subset)
+        >>> violin_files = get_files_for_instrument(
+                'violin', multitrack_subset
+            )
 
     Args:
         instrument (str): Instrument files to extract.
-        multitrack_list (list of MultiTracks, optional): 
-            List of MultiTrack objects. 
+        multitrack_list (list of MultiTracks, optional):
+            List of MultiTrack objects.
             If None, uses all multitracks.
 
     Returns:
@@ -88,7 +90,7 @@ def get_files_for_instrument(instrument, multitrack_list=None):
 
     """
     assert M.is_valid_instrument(instrument), \
-            "%s is not in the instrument taxonomy." % instrument
+        "%s is not in the instrument taxonomy." % instrument
 
     if not multitrack_list:
         multitrack_list = load_all_multitracks()
@@ -113,15 +115,16 @@ def preview_audio(multitrack, selection='all', preview_length=8):
         >>> preview_audio('/path/to/ArtistName_TrackName', selection='stems')
 
     Args:
-        multitrack (MultiTrack or str): An instance of the class MultiTrack or 
+        multitrack (MultiTrack or str): An instance of the class MultiTrack or
             a path to a multitrack folder.
         selection (str, optional): Determines which audio to play.
             'all' plays mix, stems, and raw.
             'stems' plays only the stems.
             'raw' plays only the raw audio.
             'mix' plays only the mix.
-        preview_length (float, optional): Number of seconds of audio to preview.
-        
+        preview_length (float, optional): Number of seconds of audio to
+        preview.
+
     """
 
     if isinstance(multitrack, M.MultiTrack):

--- a/scripts/fill_tony_file.py
+++ b/scripts/fill_tony_file.py
@@ -8,7 +8,7 @@ Created by Rachel Bittner <rmb456@nyu.edu>
 and Justin Salamon <justin.salamon@nyu.edu>
 
 This code is released as part of the MedleyDB library for working
-with the MedleyDB dataset: http://marl.smusic.nyu.edu/medleydb. 
+with the MedleyDB dataset: http://marl.smusic.nyu.edu/medleydb.
 
 This code is a component of the work presented in the following publication:
 
@@ -23,8 +23,8 @@ import numpy as np
 import csv
 import argparse
 
-HOP = 256.0 #Tony default hop size
-FS = 44100.0 #Tony default output sample rate
+HOP = 256.0  # Tony default hop size
+FS = 44100.0  # Tony default output sample rate
 
 
 def read_tony_file(fpath):
@@ -104,7 +104,7 @@ def sec_to_idx(time_in_seconds, sample_rate=FS, hop=HOP):
     -------
     array_idx : int
         Index of time stamp in filled f0 array.
-    """ 
+    """
     return int(np.round(time_in_seconds*sample_rate/hop))
 
 
@@ -117,7 +117,7 @@ def write_f0_to_csv(f0_sequence, output_file_path):
         Filled f0 sequence with corresponding time stamps.
     output_file_path : str
         Path to save csv file.
-    """     
+    """
     assert len(f0_sequence) != 0, "f0 sequence is empty."
     with open(output_file_path, "wb") as fpath:
         writer = csv.writer(fpath)
@@ -150,22 +150,22 @@ def main(args):
         time_idx = sec_to_idx(time)
         if time_idx >= start_idx and time_idx < end_idx:
             f0_sequence[time_idx][1] = freq
-    
+
     write_f0_to_csv(f0_sequence, args.outputfile)
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description="Fill in missing time frames in a Tony file," 
+        description="Fill in missing time frames in a Tony file,"
                     "write the output to file.")
-    parser.add_argument("tonyfile", 
-                        type=str, 
+    parser.add_argument("tonyfile",
+                        type=str,
                         help="Path to tony ouput csv file.")
-    parser.add_argument("outputfile", 
-                        type=str, 
+    parser.add_argument("outputfile",
+                        type=str,
                         help="Path to save location of filled in file.")
-    parser.add_argument("duration", 
-                        type=float, 
+    parser.add_argument("duration",
+                        type=float,
                         help="Length (in seconds) of annotation audio file.")
 
     main(parser.parse_args())

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
 [pytest]
-addopts = --ignore scripts --cov-report term-missing --cov medleydb
+addopts = --ignore scripts --cov-report term-missing --cov medleydb --pep8
+pep8ignore = E402

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -1,5 +1,6 @@
 import medleydb as mdb
 
+
 def test_all():
     assert len(mdb.load_all_multitracks()) > 0
 

--- a/tests/test_sox.py
+++ b/tests/test_sox.py
@@ -1,6 +1,7 @@
 import medleydb as mdb
 from medleydb import sox
 
+
 def noop(*args, **kwargs):
     pass
 

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -2,6 +2,7 @@ import pytest
 
 import medleydb as mdb
 
+
 @pytest.fixture(params=(
     'violin',
 ))


### PR DESCRIPTION
We have grown accustomed to coding according to the [PEP8](https://www.python.org/dev/peps/pep-0008/) guidelines and are very happy with it. Also, our editors flash hysterically if there are PEP8 violations in the file :-)

This PR fixes the few PEP8- and whitespace-errors that were in the code. There were no functional changes at all. Also, Pytest now tests for PEP8 compliance.