### PR TITLE
Fixed setup.py and manifest.in to include taxonomy.yaml in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include medleydb/taxonomy.yaml

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     url='https://github.com/rabitt3/medleydb',
     download_url='http://github.com/rabitt3/medleydb/releases',
     packages=['medleydb'],
-    package_data={'': ['example_data/*']},
+    package_data={'medleydb': ['taxonomy.yaml']},
     long_description="""A python module for audio and music processing.""",
     classifiers=[
         "License :: The MIT License (MIT)",


### PR DESCRIPTION
This PR makes sure that `sdist`s contain the `taxonomy.yml` file:

    python setup.py sdist

creates a file `dist/medleydb-0.1.0.tar.gz` file which should be installable using `pip install` (we put regularily needed packages on an intranet server for everyone to use). Currently, the all important `taxonomy.yml` file was missing.